### PR TITLE
making +1 & -1 shortcut syntax consistent

### DIFF
--- a/js/jquery.emojipicker.a.js
+++ b/js/jquery.emojipicker.a.js
@@ -2885,7 +2885,7 @@ window.emojis = [
   {
     "name": "+1",
     "unicode": "1F44D",
-    "shortcode": "plus1",
+    "shortcode": "+1", 
     "description": "THUMBS UP SIGN",
     "category": "people"
   },


### PR DESCRIPTION
also @selby is it possible to have multiple shortcodes e.g., `thumbsup` and `thumbsdown` for + and -1? Not sure if there was a reason thumbsup had `'plus1` shortcode whereas thumbsdown had `-1` shortcut just FYI
